### PR TITLE
21 workflow fix docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Save state
+        run: echo "{name}={value}" >> $GITHUB_STATE
+
+      - name: Set output
+        run: echo "{name}={value}" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,6 +24,7 @@ jobs:
           sudo chmod -R 777 /home/ubuntu/actions-runner/_work/pong/pong/*
           docker volume rm $(docker volume ls -qf dangling=true)
           docker system prune -af
+          sudo find /home/ubuntu/actions-runner/_work/pong/pong/* -delete
           sudo rm -rf /home/ubuntu/actions-runner/_work/pong/pong/*
 
         continue-on-error: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,10 +22,15 @@ jobs:
       - name: Cleaning
         run: |
           sudo chmod -R 777 /home/ubuntu/actions-runner/_work/pong/pong/*
+          docker compose down
+          if [[ $(docker volume ls -qf dangling=true) ]]; then
           docker volume rm $(docker volume ls -qf dangling=true)
+          fi
+          
           docker system prune -af
           sudo find /home/ubuntu/actions-runner/_work/pong/pong/* -delete
           sudo rm -rf /home/ubuntu/actions-runner/_work/pong/pong/*
+        shell: /usr/bin/bash -e {0}
 
         continue-on-error: true
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - name: Cleaning
         run: |
-#         Make files in the work directory writable for all users (use with caution)
           sudo chmod -R 777 /home/ubuntu/actions-runner/_work/pong/pong/*
           
 #          Stop and remove existing containers defined in docker-compose.yml

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,27 +20,19 @@ jobs:
     steps:
       - name: Cleaning
         run: |
-#         Make files in the work directory writable for all users (use with caution)
           sudo chmod -R 777 /home/ubuntu/actions-runner/_work/pong/pong/*
-          
-#          Stop and remove existing containers defined in docker-compose.yml
           docker compose down
           
-#          Check if there are dangling volumes and remove them if found
           if [[ $(docker volume ls -qf dangling=true) ]]; then
             docker volume rm $(docker volume ls -qf dangling=true)
           fi
           
-#          Prune all unused Docker resources
           docker system prune -af
           
-#          Delete all files and subdirectories in the work directory
           sudo find /home/ubuntu/actions-runner/_work/pong/pong/* -delete
           
-#          Recursively remove the work directory itself (use with caution)
           sudo rm -rf /home/ubuntu/actions-runner/_work/pong/pong/*
 
-#          This run needs to be done in bash commands
         shell: bash -e {0}
 
         continue-on-error: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,7 +3,7 @@ name: Build Docker Images
 on:
   push:
     branches:
-      - 21-workflow-fix-docker-image
+      - main
 
 jobs:
   build-on-push:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,7 +18,6 @@ jobs:
       DOCKER_SERVER: ${{ secrets.DOCKER_IP }}
 
     steps:
-
       - name: Cleaning
         run: |
 #         Make files in the work directory writable for all users (use with caution)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,35 +21,46 @@ jobs:
 
       - name: Cleaning
         run: |
+#         Make files in the work directory writable for all users (use with caution)
           sudo chmod -R 777 /home/ubuntu/actions-runner/_work/pong/pong/*
+          
+#          Stop and remove existing containers defined in docker-compose.yml
           docker compose down
+          
+#          Check if there are dangling volumes and remove them if found
           if [[ $(docker volume ls -qf dangling=true) ]]; then
-          docker volume rm $(docker volume ls -qf dangling=true)
+            docker volume rm $(docker volume ls -qf dangling=true)
           fi
           
+#          Prune all unused Docker resources
           docker system prune -af
+          
+#          Delete all files and subdirectories in the work directory
           sudo find /home/ubuntu/actions-runner/_work/pong/pong/* -delete
+          
+#          Recursively remove the work directory itself (use with caution)
           sudo rm -rf /home/ubuntu/actions-runner/_work/pong/pong/*
+
+#          This run needs to be done in bash commands
         shell: /usr/bin/bash -e {0}
 
         continue-on-error: true
 
       - name: Checkout code
         uses: actions/checkout@v2
+#        Cloning the repository's source code from the default branch into the Actions runner environment.
 
       - name: Save state
         run: echo "{name}={value}" >> $GITHUB_STATE
-
       - name: Set output
         run: echo "{name}={value}" >> $GITHUB_OUTPUT
+#        Ask by Github Actions : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+#        Prepares the environment to use Docker Buildx for building Docker images.
 
       - name: Build and push API image
         run: |
-          echo "$MY_ENV_VARIABLE" > .env
           docker-compose up -d --build
-          docker-compose logs
-        env:
-          MY_ENV_VARIABLE: ${{ secrets.MY_ENV_VARIABLE }}
+          docker-compose logs --follow

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,7 @@ on:
       - 21-workflow-fix-docker-image
 
 jobs:
-  build-and-push:
+  build-on-push:
     runs-on: self-hosted
 
     env:
@@ -22,9 +22,9 @@ jobs:
       - name: Cleaning
         run: |
           sudo chmod -R 777 /home/ubuntu/actions-runner/_work/pong/pong/*
-          sudo rm -rf /home/ubuntu/actions-runner/_work/pong/pong/*
           docker volume rm $(docker volume ls -qf dangling=true)
           docker system prune -af
+          sudo rm -rf /home/ubuntu/actions-runner/_work/pong/pong/*
 
         continue-on-error: true
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: Cleaning
         run: |
+#         Make files in the work directory writable for all users (use with caution)
           sudo chmod -R 777 /home/ubuntu/actions-runner/_work/pong/pong/*
           
 #          Stop and remove existing containers defined in docker-compose.yml

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,5 +53,8 @@ jobs:
 
       - name: Build and push API image
         run: |
+          echo "$MY_ENV_VARIABLE" > .env
           docker-compose up -d --build
-          docker-compose logs --follow
+          docker-compose logs
+        env:
+          MY_ENV_VARIABLE: ${{ secrets.MY_ENV_VARIABLE }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: self-hosted
 
     env:
-      POSTGRES_USER: ${{ pong_secrets.POSTGRES_USER }}
-      POSTGRES_PASSWORD: ${{ pong_secrets.POSTGRES_PASSWORD }}
-      POSTGRES_DB: ${{ pong_secrets.POSTGRES_DB }}
-      PGADMIN_DEFAULT_EMAIL: ${{ pong_secrets.PGADMIN_DEFAULT_EMAIL }}
-      PGADMIN_DEFAULT_PASSWORD: ${{ pong_secrets.PGADMIN_DEFAULT_PASSWORD }}
-      DOCKER_SERVER: ${{ pong_secrets.DOCKER_IP }}
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+      PGADMIN_DEFAULT_EMAIL: ${{ secrets.PGADMIN_DEFAULT_EMAIL }}
+      PGADMIN_DEFAULT_PASSWORD: ${{ secrets.PGADMIN_DEFAULT_PASSWORD }}
+      DOCKER_SERVER: ${{ secrets.DOCKER_IP }}
 
     steps:
       - name: Cleaning
@@ -41,7 +41,7 @@ jobs:
           sudo rm -rf /home/ubuntu/actions-runner/_work/pong/pong/*
 
 #          This run needs to be done in bash commands
-        shell: /usr/bin/bash -e {0}
+        shell: bash -e {0}
 
         continue-on-error: true
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,7 +3,7 @@ name: Build Docker Images
 on:
   push:
     branches:
-      - dev
+      - 21-workflow-fix-docker-image
 
 jobs:
   build-and-push:
@@ -15,7 +15,7 @@ jobs:
       POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
       PGADMIN_DEFAULT_EMAIL: ${{ secrets.PGADMIN_DEFAULT_EMAIL }}
       PGADMIN_DEFAULT_PASSWORD: ${{ secrets.PGADMIN_DEFAULT_PASSWORD }}
-      DOCKER_SERVER: 195.15.213.225:2375
+      DOCKER_SERVER: ${{ secrets.DOCKER_IP }}
 
     steps:
 
@@ -23,6 +23,10 @@ jobs:
         run: |
           sudo chmod -R 777 /home/ubuntu/actions-runner/_work/pong/pong/*
           sudo rm -rf /home/ubuntu/actions-runner/_work/pong/pong/*
+          docker volume rm $(docker volume ls -qf dangling=true)
+          docker system prune -af
+
+        continue-on-error: true
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -34,6 +38,6 @@ jobs:
         run: |
           echo "$MY_ENV_VARIABLE" > .env
           docker-compose up -d --build
+          docker-compose logs
         env:
           MY_ENV_VARIABLE: ${{ secrets.MY_ENV_VARIABLE }}
-        

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: self-hosted
 
     env:
-      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
-      PGADMIN_DEFAULT_EMAIL: ${{ secrets.PGADMIN_DEFAULT_EMAIL }}
-      PGADMIN_DEFAULT_PASSWORD: ${{ secrets.PGADMIN_DEFAULT_PASSWORD }}
-      DOCKER_SERVER: ${{ secrets.DOCKER_IP }}
+      POSTGRES_USER: ${{ pong_secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ pong_secrets.POSTGRES_PASSWORD }}
+      POSTGRES_DB: ${{ pong_secrets.POSTGRES_DB }}
+      PGADMIN_DEFAULT_EMAIL: ${{ pong_secrets.PGADMIN_DEFAULT_EMAIL }}
+      PGADMIN_DEFAULT_PASSWORD: ${{ pong_secrets.PGADMIN_DEFAULT_PASSWORD }}
+      DOCKER_SERVER: ${{ pong_secrets.DOCKER_IP }}
 
     steps:
       - name: Cleaning

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,12 +41,6 @@ jobs:
         uses: actions/checkout@v2
 #        Cloning the repository's source code from the default branch into the Actions runner environment.
 
-      - name: Save state
-        run: echo "{name}={value}" >> $GITHUB_STATE
-      - name: Set output
-        run: echo "{name}={value}" >> $GITHUB_OUTPUT
-#        Ask by Github Actions : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 #        Prepares the environment to use Docker Buildx for building Docker images.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,8 +53,6 @@ jobs:
 
       - name: Build and push API image
         run: |
-          echo "$MY_ENV_VARIABLE" > .env
+          touch .env
           docker-compose up -d --build
           docker-compose logs
-        env:
-          MY_ENV_VARIABLE: ${{ secrets.MY_ENV_VARIABLE }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DATA=./data/
 
 all:
 	$(CMD) docker-compose.yml up --build -d
+	docker-compose logs --follow
 
 build:
 	$(CMD) docker-compose.yml build


### PR DESCRIPTION
Goal: all fix and working -> building at every push on main

Next issue: localhost hardcode in files, so it won't be available online for now.

Explain:
touch .env = docker-compose.yml needs a .env reference, even if it's empty
env variables are in secrets stored in github settings

Cleaning part will erase everyting on the serveur 

Improve possible: select special containers and volumes, to replace "docker system prune -a" commands