### PR TITLE
51 back endpoint accept friend senderid compare with targetid

### DIFF
--- a/front/src/containers/social/friend/Friends.tsx
+++ b/front/src/containers/social/friend/Friends.tsx
@@ -8,7 +8,7 @@ import {getPath} from "../../../api";
 
 
 const states = ["En ligne","Tous","En attente","Bloqué","Ajouter"];
-const paths = ["/users/friend/online/","/users/friend/","/friend/friend-request/pending/","/block/blocked/"]
+const paths = ["/users/friend/online/","/users/friend/","/users/friend-request/pending/","/block/blocked/"]
 
 export default function Friends(){
     const [state, setState] = useState("En ligne");

--- a/front/src/css/notification.css
+++ b/front/src/css/notification.css
@@ -15,6 +15,7 @@
 .notification {
     display: flex;
     flex-direction: row;
+    pointer-events: auto;
 }
 
 


### PR DESCRIPTION
```
    if (friendship.targetId != acceptorId)
      throw new Error('Both acceptorId and targetId should be the same');